### PR TITLE
using span and not const char** as it is not safe

### DIFF
--- a/examples/read/read_json.cpp
+++ b/examples/read/read_json.cpp
@@ -1,7 +1,6 @@
 #include "json_istream.h"
 #include "json_ostream.h"
 #include "json_utils.h"
-#include <boost/filesystem.hpp> 
 #include <vector>
 #include <string>
 #include <iostream>

--- a/examples/structs/struct_example.cpp
+++ b/examples/structs/struct_example.cpp
@@ -30,7 +30,7 @@ auto operator ^ (json::ostream& os, const foo& f) -> json::ostream& {
         "A", "B", "C", "S"
     };
 
-    return json::util::serialized(os, f, &LABELS[0]);
+    return json::util::serialized(os, f, LABELS);
 }
 
 auto operator ^ (json::istream& os, foo& f) -> json::istream& {
@@ -38,7 +38,7 @@ auto operator ^ (json::istream& os, foo& f) -> json::istream& {
         "A", "B", "C", "S"
     };
 
-    return json::util::deserialized(os, f, &LABELS[0]);
+    return json::util::deserialized(os, f, LABELS);
 }
 
 struct bar {
@@ -62,7 +62,7 @@ auto operator ^ (json::ostream& os, const bar& f) -> json::ostream& {
         "int values", "double values"
     };
 
-    return json::util::serialized(os, f, &LABELS[0]);
+    return json::util::serialized(os, f, LABELS);
 }
 
 auto operator ^ (json::istream& os, bar& f) -> json::istream& {
@@ -70,7 +70,7 @@ auto operator ^ (json::istream& os, bar& f) -> json::istream& {
         "int values", "double values"
     };
 
-    return json::util::deserialized(os, f, &LABELS[0]);
+    return json::util::deserialized(os, f, LABELS);
 }
 
 struct baz {
@@ -88,7 +88,7 @@ auto operator ^ (json::ostream& os, const baz& f) -> json::ostream& {
         "foo", "baz"
     };
 
-    return json::util::build_entry(os, f, &LABELS[0]);
+    return json::util::build_entry(os, f, LABELS);
 }
 
 auto operator ^ (json::istream& os, baz& f) -> json::istream& {
@@ -96,7 +96,7 @@ auto operator ^ (json::istream& os, baz& f) -> json::istream& {
         "foo", "baz"
     };
 
-    return json::util::read_entry(os, f, &LABELS[0]);
+    return json::util::read_entry(os, f, LABELS);
 }
 
 


### PR DESCRIPTION
In this PR we will replace the use of `const char**` to the functions that translate from `struc` into JSON and back with the C++ 20 span.
- Span is safe in that it has a size on it.
- We can verify that the number of data member is the class/struct matches that of the labels that we are passing in the span.
- We can verify that the iteration over the data members matches that of the number of labels at run time.
